### PR TITLE
Database engine tweaks & small schema tweak

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ requests==2.23.0
 SQLAlchemy==1.3.5
 Werkzeug==0.15.5
 matplotlib==3.2.1
+flask-sqlalchemy==2.4.3
+psycogreen==1.0.2

--- a/ruqqus/__main__.py
+++ b/ruqqus/__main__.py
@@ -27,8 +27,6 @@ app = Flask(__name__,
            )
 app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=2)
 
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['SQLALCHEMY_DATABASE_URI'] = environ.get("DATABASE_URL")
 app.config['SECRET_KEY']=environ.get('MASTER_KEY')
 app.config["SERVER_NAME"]=environ.get("domain", None)
 app.config["SESSION_COOKIE_NAME"]="session_ruqqus"
@@ -71,9 +69,19 @@ limiter = Limiter(
 )
 
 #setup db
-_engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'])
-db = sessionmaker(bind=_engine)()
+from flask_sqlalchemy import SQLAlchemy
+import psycogreen.gevent
+psycogreen.gevent.patch_psycopg()
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_DATABASE_URI'] = environ.get("DATABASE_URL")
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+    'pool_size': int(environ.get('SQLALCHEMY_POOL_SIZE', 6)),
+    'max_overflow': int(environ.get('SQLALCHEMY_MAX_OVERFLOW', 6))
+}
+app.db = SQLAlchemy(app)
+db = app.db.session
 Base = declarative_base()
+
 
 #import and bind all routing functions
 import ruqqus.classes

--- a/schema.txt
+++ b/schema.txt
@@ -1380,6 +1380,7 @@ CREATE TABLE public.ips (
     banned_by integer
 );
 
+CREATE UNIQUE INDEX ips_addr_uq ON public.ips (addr);
 
 --
 -- Name: ips_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1607,6 +1608,7 @@ CREATE TABLE public.useragents (
     status_code integer DEFAULT 418
 );
 
+CREATE UNIQUE INDEX useragents_kwd_uq ON public.useragents (kwd);
 
 --
 -- Name: useragents_id_seq; Type: SEQUENCE; Schema: public; Owner: -

--- a/schema.txt
+++ b/schema.txt
@@ -1380,7 +1380,6 @@ CREATE TABLE public.ips (
     banned_by integer
 );
 
-CREATE UNIQUE INDEX ips_addr_uq ON public.ips (addr);
 
 --
 -- Name: ips_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1607,8 +1606,6 @@ CREATE TABLE public.useragents (
     mock character varying(256) DEFAULT ''::character varying,
     status_code integer DEFAULT 418
 );
-
-CREATE UNIQUE INDEX useragents_kwd_uq ON public.useragents (kwd);
 
 --
 -- Name: useragents_id_seq; Type: SEQUENCE; Schema: public; Owner: -


### PR DESCRIPTION
* Use psycogreen to allow postgres driver to be used asynchronously
* Use Flask-SQLAlchemy to scope our sessions to a request context
* Add unique indexes for blocked ip's and user agents

In the current implementation, the application creates a single database session upon start-up, all operations go through this session, and in-flight database requests through this session do not result in yielding control to other flask requests. This means each flask request blocks until the completion of the database queries for the previous flask request.

By using psycogreen, we can instruct the database driver to yield control while queries are in progress-- improving concurrency; however, because there's only a single global session, this will result in errors due to multiple flask requests attempting to use the same database session.

In order to prevent those errors, we can use flask-sqlalchemy to provide one sqlalchemy session per flask request. Since we can now have multiple sessions instantiated at the same time, it also means that we can have multiple connections to the database at the same time (as opposed to one database connection per process in the existing implementation), which is a win for performance.

The number of connections can be configured via the pool_size and max_overflow parameters. Pool size gives the number of (lazily created) connections to be kept open and max overflow gives the maximum number of ephemeral connections to be created as needed. 

Based on the `--worker-connections` parameter in the Procfile, I have set the pool size to 6 by default. Both numbers could easily go higher so long as you don't exceed the maximum number of connections that your database supports.

Engine settings aside, I've added a unique index to the ip's and user agents tables, which will make the check for banned ip's and user agents faster.