### PR TITLE
Open link in new tab to preserve form

### DIFF
--- a/ruqqus/templates/settings_profile.html
+++ b/ruqqus/templates/settings_profile.html
@@ -340,7 +340,7 @@
                      {% endfor %}
                    </select>
                  </div>
-                 <div class="text-small-extra text-muted mt-3"><a href="/help/titles">Click here</a> to see all titles and the requirements to unlock them.</div>
+                 <div class="text-small-extra text-muted mt-3"><a href="/help/titles" target="_blank">Click here</a> to see all titles and the requirements to unlock them.</div>
 
                </div>
 


### PR DESCRIPTION
Fixes issue #250 by just opening the titles link in a new tab rather than in current tab, this will save the form the user is currently messing with for their profile and prevent the error from happening.

Its a small fix but will save users a headache when they go to view titles then lose all of their changes to their profile because they clicked on the link before saving.