### PR TITLE
Fix offensive check

### DIFF
--- a/ruqqus/routes/posts.py
+++ b/ruqqus/routes/posts.py
@@ -109,13 +109,11 @@ def edit_post(pid, v):
     p.edited_utc = int(time.time())
 
     #offensive
+    p.is_offensive=False
     for x in g.db.query(BadWord).all():
         if (p.body and x.check(p.body)) or x.check(p.title):
             p.is_offensive=True
-            break
-        else:
-            p.is_offensive=False
-    
+            break   
 
     return redirect(p.permalink)
 
@@ -369,12 +367,11 @@ def submit_post(v):
         abort(403)
 
     #offensive
+    is_offensive=False
     for x in g.db.query(BadWord).all():
         if (body and x.check(body)) or x.check(title):
             is_offensive=True
             break
-        else:
-            is_offensive=False
 
     new_post=Submission(#title=title,
           #              url=url,


### PR DESCRIPTION
## Description
Makes it so that is_offensive will not be undefined if the list of offensive words is empty. Also makes it so it isn't constantly re-defining the is_offensive variable as false every time the offensive words are not found in the post, just defines it as false to begin with and then defines it as true and breaks out if a match is found.

## Motivation and Context
It fixes an error when trying to make posts when there is an empty list of offensive words.

## How Has This Been Tested?
I followed the setup guide on Arch Linux to set up Ruqqus locally (not word for word, obviously, but I took the equivalent steps)
I made three posts to make sure posting worked and there were no errors, everything worked fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
