### PR TITLE
should be author.username instead of author_name

### DIFF
--- a/ruqqus/classes/comment.py
+++ b/ruqqus/classes/comment.py
@@ -231,7 +231,7 @@ class Comment(Base, Age_times, Scores, Stndrd, Fuzzing):
                 'post':self.post.base36id,
                 'level':self.level,
                 'parent':self.parent_fullname,
-                'author':self.author_name if not self.author.is_deleted else None,
+                'author':self.author.username if not self.author.is_deleted else None,
                 'body':self.body,
                 'body_html':self.body_html,
             #   'replies': [x.json for x in self.replies]


### PR DESCRIPTION
I believe this was breaking the '/api/v1/comment/\<id\>' route. There is no author_name attribute. I think you meant author.username.