### PR TITLE
dms should resolve with 403 when accessed from comment api

### DIFF
--- a/ruqqus/routes/api/json_api.py
+++ b/ruqqus/routes/api/json_api.py
@@ -40,7 +40,7 @@ def comment_info(v, cid):
     comment=get_comment(cid)
 
     post=comment.post
-    if not post.is_public and post.board.is_private and not post.board.can_view(v):
+    if not post or not post.is_public and post.board.is_private and not post.board.can_view(v):
         abort(403)
         
     return jsonify(comment.json)


### PR DESCRIPTION
Resolve with a 403 when someone tries to access a comment that has no post_id (such as dms) from the api. For example [this comment](https://ruqqus.com/api/v1/comment/vsk) causes a 500 error.


## How Has This Been Tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
