### PR TITLE
add keys to comment json api

### DIFF
--- a/ruqqus/classes/comment.py
+++ b/ruqqus/classes/comment.py
@@ -234,9 +234,17 @@ class Comment(Base, Age_times, Scores, Stndrd, Fuzzing):
                 'author':self.author.username if not self.author.is_deleted else None,
                 'body':self.body,
                 'body_html':self.body_html,
-            #   'replies': [x.json for x in self.replies]
                 'is_archived':self.is_archived,
-                'title': self.title.json if self.title else None
+                'title':self.title.json if self.title else None,
+                'guild_name':self.board.name,
+                'created_utc':self.created_utc,
+                'edited_utc':self.edited_utc or 0,
+                'is_banned':False,
+                'is_deleted':False,
+                'is_nsfw':self.over_18,
+                'is_offensive':self.is_offensive,
+                'is_nsfl':self.is_nsfl,
+                'permalink':self.permalink
                 }
             
     @property


### PR DESCRIPTION

##  Description
Added keys to Comment class's json property to make it more like Post.json.


## Motivation and Context
currently the comment api does not return important information such as created_utc. Much of this data is in the post api so I felt it should be added to be consistent. It's also easily available via HTML.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Potential improvements

There are some potential improvements that I wasn't sure would be merged if added. Though I can add them if the maintainers are interested:

- A score key to both the comment and post api.
- An original_board_name key to the comment api.
- I think the 'title' key in the comment api should be changed to 'author_title' to be consistent with the post api.