### PR TITLE
Keep the current sort by when clicking the "all" link in the left sidebar

### DIFF
--- a/ruqqus/templates/mobile_navigation_bar.html
+++ b/ruqqus/templates/mobile_navigation_bar.html
@@ -14,7 +14,7 @@
         </div>
 {% endif %}
         <div class="col px-0">
-            <a href="/all?sort=new" class="text-decoration-none" role="button">
+            <a href="/all?sort={{ request.args.get('sort') or 'new' }}" class="text-decoration-none" role="button">
                 <div class="text-center {% if request.path=='/all' and sort_method=='new' %}text-purple{% else %}text-muted{% endif %}">
                     <i class="fas fa-globe-americas text-lg d-block"></i>
                     <div class="text-small">New</div>

--- a/ruqqus/templates/sidebar-left.html
+++ b/ruqqus/templates/sidebar-left.html
@@ -29,7 +29,7 @@
               </a>
             </li>
             <li class="guild-recommendations-item">
-              <a href="/all?sort=new">
+              <a href="/all?sort={{ request.args.get('sort') or 'new' }}">
                 <div class="d-flex">
                   <div>
                     <img src="/assets/images/icons/planet.png" class="profile-pic profile-pic-30"></div>
@@ -59,7 +59,7 @@
                   </a>
                 </li>
                 <li class="guild-recommendations-item">
-                  <a href="/all?sort=new">
+                  <a href="/all?sort={{ request.args.get('sort') or 'new' }}">
                     <img src="/assets/images/icons/planet.png" class="profile-pic profile-pic-30 transition-square">
                   </a>
                 </li>


### PR DESCRIPTION
## Description
When clicking the "all" link in the left sidebar keep the current sort by, if no sort parameter is set use sort by "new".

## Motivation and Context
I like to use the "Hot" sort by, if I click the "all" link, then the "new" sort by is set automatically and I have to set "Hot" again. I guess I'm not the only one who's annoyed by this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
