### PR TITLE
Fix Typo

### DIFF
--- a/ruqqus/templates/help/titles.html
+++ b/ruqqus/templates/help/titles.html
@@ -43,7 +43,7 @@
 
 <h2 class="h3" id="SupporterTitles">Supporter titles</h2>
 
-<p>These titles can be obtained by financially supporing Ruqqus.</p>
+<p>These titles can be obtained by financially supporting Ruqqus.</p>
 
 <table class="table table-striped mb-5">
 	<thead class="bg-primary text-white">


### PR DESCRIPTION
Fixes a typo on the Titles page, "supporing" to "supporting".