### PR TITLE
#366: Add missing param in links

### DIFF
--- a/ruqqus/templates/search.html
+++ b/ruqqus/templates/search.html
@@ -131,11 +131,11 @@
                 {{ sort_method }}
               </button>
               <div class="dropdown-menu" id="mobileSortDropdown" aria-labelledby="dropdownMenuButtonMobile" x-placement="bottom-start" style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(0px, 31px, 0px);">
-                {% if not sort_method=="hot" %}<a class="dropdown-item" href="?sort=hot"><i class="fas fa-fire text-primary mr-3"></i>Hot</a>{% endif %}
-                {% if not sort_method=="top" %}<a class="dropdown-item" href="?sort=top"><i class="fas fa-arrow-alt-circle-up text-primary mr-3"></i>Top</a>{% endif %}
-                {% if not sort_method=="new" %}<a class="dropdown-item" href="?sort=new"><i class="fas fa-sparkles text-primary mr-3"></i>New</a>{% endif %}
-                {% if not sort_method=="disputed" %}<a class="dropdown-item" href="?sort=disputed"><i class="fas fa-bullhorn text-primary mr-3"></i>Disputed</a>{% endif %}
-                {% if not sort_method=="activity" %}<a class="dropdown-item" href="?sort=activity"><i class="fas fa-comments text-primary mr-3"></i>Activity</a>{% endif %}
+                {% if not sort_method=="hot" %}<a class="dropdown-item" href="?sort=hot&q={{ query | urlencode }}"><i class="fas fa-fire text-primary mr-3"></i>Hot</a>{% endif %}
+                {% if not sort_method=="top" %}<a class="dropdown-item" href="?sort=top&q={{ query | urlencode }}"><i class="fas fa-arrow-alt-circle-up text-primary mr-3"></i>Top</a>{% endif %}
+                {% if not sort_method=="new" %}<a class="dropdown-item" href="?sort=new&q={{ query | urlencode }}"><i class="fas fa-sparkles text-primary mr-3"></i>New</a>{% endif %}
+                {% if not sort_method=="disputed" %}<a class="dropdown-item" href="?sort=disputed&q={{ query | urlencode }}"><i class="fas fa-bullhorn text-primary mr-3"></i>Disputed</a>{% endif %}
+                {% if not sort_method=="activity" %}<a class="dropdown-item" href="?sort=activity&q={{ query | urlencode }}"><i class="fas fa-comments text-primary mr-3"></i>Activity</a>{% endif %}
               </div>
             </div>
 


### PR DESCRIPTION
This resolves #366

## Description
`q` param was missing, which was the reason of the 500 server error.

## Screenshots (if appropriate):
![Screenshot from 2020-07-31 14-18-51](https://user-images.githubusercontent.com/11054478/89067382-2a0a3800-d33d-11ea-99ef-c6a46b7c6e9e.png)
![Screenshot from 2020-07-31 14-19-00](https://user-images.githubusercontent.com/11054478/89067387-2bd3fb80-d33d-11ea-9330-0b918b67af64.png)
![Screenshot from 2020-07-31 14-19-13](https://user-images.githubusercontent.com/11054478/89067392-2d052880-d33d-11ea-8fa1-23cb646e755c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
