### PR TITLE
Removed the choppy white borders around icons in dark mode

### DIFF
--- a/ruqqus/assets/style/main_dark.css
+++ b/ruqqus/assets/style/main_dark.css
@@ -15069,7 +15069,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   text-align: center;
   object-fit: cover;
   color: #FFFFFF;
-  background-color: #FFFFFF;
 }
 
 .profile-pic .letter {
@@ -15109,7 +15108,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-25 {
@@ -15118,7 +15116,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-30 {
@@ -15127,7 +15124,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-35 {
@@ -15136,7 +15132,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-40 {
@@ -15145,7 +15140,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-50 {
@@ -15154,7 +15148,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-65 {
@@ -15163,7 +15156,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-75 {
@@ -15172,7 +15164,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-100 {
@@ -15181,7 +15172,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
   border-radius: 50%;
   text-align: center;
   object-fit: cover;
-  background-color: #FFFFFF;
 }
 
 .profile-pic-overlap {

--- a/ruqqus/assets/style/main_dark.scss
+++ b/ruqqus/assets/style/main_dark.scss
@@ -1647,7 +1647,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     text-align: center;
     object-fit: cover;
     color: $white;
-    background-color: #FFFFFF;
 }
 
 .profile-pic .letter {
@@ -1687,7 +1686,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-25 {
@@ -1696,7 +1694,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-30 {
@@ -1705,7 +1702,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-35 {
@@ -1714,7 +1710,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-40 {
@@ -1723,7 +1718,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-50 {
@@ -1732,7 +1726,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-65 {
@@ -1741,7 +1734,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-75 {
@@ -1750,7 +1742,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-100 {
@@ -1759,7 +1750,6 @@ a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {
     border-radius: 50%;
     text-align: center;
     object-fit: cover;
-    background-color: #FFFFFF;
 }
 
 .profile-pic-overlap {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Very small fix, on Dark mode icons had a choppy white border around them due to background-color being set to white. I fixed this by removing the attribute.

Here's a comparison album on imgur: https://imgur.com/a/XxLrAPW

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It looks choppy and doesn't blend with the dark mode color. This fixes it to be much smoother, making the UI more appealing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I was able to add the changes from #275 to the latest version of the repository and run ruqqus in docker. I made the specified changes to the css and scss files and can confirm that it works. I also used inspect element in my browser on the main site, which this fix also works on.

## Screenshots (if appropriate):
Here's a comparison album on imgur: https://imgur.com/a/XxLrAPW

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
