### PR TITLE
Makes comments display the number of upvotes and downvotes in the information bar (next to the timestamp)

### DIFF
--- a/ruqqus/templates/comments.html
+++ b/ruqqus/templates/comments.html
@@ -51,6 +51,8 @@
 {% else %}
 
 {% set score=c.score_fuzzed %}
+{% set upvotes=c.upvotes_fuzzed %}
+{% set downvotes=c.downvotes_fuzzed %}
 {% if v %}
 {% set voted=c.voted %}
 {% set adjust = voted %}
@@ -93,7 +95,7 @@
         {% if c.is_blocking %}
         <i class="fas fa-user-minus text-danger" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="This user is blocking you, but you can see this comment becuase it's in your guild."></i>
         {% endif %}
-        <span class="time-stamp"> · {{ c.age_string }}</span>{% if standalone and c.parent_submission and not c.is_public %} · <i class="fas fa-eye-slash text-muted" data-toggle="tooltip" data-placement="bottom" title="Private content, visible because {{ c.visibility_reason(v) }}"></i>{% endif %}
+        <span class="time-stamp"> · {{ c.age_string }}</span><span> · Votes: +{{ upvotes }}/-{{ downvotes }}</span>{% if standalone and c.parent_submission and not c.is_public %} · <i class="fas fa-eye-slash text-muted" data-toggle="tooltip" data-placement="bottom" title="Private content, visible because {{ c.visibility_reason(v) }}"></i>{% endif %}
         {% if c.edited_utc %}
         <span class="time-edited"><span>&#183;</span> <span class="font-italic">Edited {{ c.edited_string }}</span></span>
         {% endif %}

--- a/ruqqus/templates/embeds/comment.html
+++ b/ruqqus/templates/embeds/comment.html
@@ -1,6 +1,8 @@
 {% extends "embeds/embed_default.html" %}
 
 {% set score=c.score_fuzzed %}
+{% set upvotes=c.upvotes_fuzzed %}
+{% set downvotes=c.downvotes_fuzzed %}
 
 {% block title %}
 <title>@{{ c.author.username }} comments in +{{ c.board.name }} on "{{ c.post.title }}"</title>
@@ -34,7 +36,7 @@
 			{% endif %}
 			<span> </span>
 		{% endif %}
-                <span class="time-stamp"><span>&#183;</span> {{ c.age_string }}</span>
+                <span class="time-stamp"><span>&#183;</span> {{ c.age_string }}</span><span><span>&#183;</span> Votes: +{{ upvotes }}/-{{ downvotes }}</span>
 		{% if c.edited_utc %}
 		<span class="time-edited"><span>&#183;</span> <span class="font-italic">Edited {{ c.edited_string }}</span></span>
 		{% endif %}

--- a/ruqqus/templates/single_comment.html
+++ b/ruqqus/templates/single_comment.html
@@ -1,4 +1,6 @@
 {% set score=c.score_fuzzed %}
+{% set upvotes=c.upvotes_fuzzed %}
+{% set downvotes=c.downvotes_fuzzed %}
 {% if v %}
 {% set voted=c.voted %}
 {% set adjust = voted %}
@@ -38,7 +40,7 @@
         {% endif %}
         <span> </span>
         {% endif %}
-        <span class="time-stamp">· {{ c.age_string }}</span>{% if standalone and c.parent_submission and not c.is_public %} · <i class="fas fa-eye-slash text-muted" data-toggle="tooltip" data-placement="bottom" title="Private content, visible because {{ c.visibility_reason(v) }}"></i>{% endif %}
+        <span class="time-stamp">· {{ c.age_string }}</span><span> · Votes: +{{ upvotes }}/-{{ downvotes }}</span>{% if standalone and c.parent_submission and not c.is_public %} · <i class="fas fa-eye-slash text-muted" data-toggle="tooltip" data-placement="bottom" title="Private content, visible because {{ c.visibility_reason(v) }}"></i>{% endif %}
         {% if c.edited_utc %}
         <span class="time-edited"><span>&#183;</span> <span class="font-italic">Edited {{ c.edited_string }}</span></span>
         {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Basically I just added the fuzzed upvote/downvote numbers to display on comments. It's displayed in the information bar at the top, next to the timestamp. This was something I know is desired, so I thought I'd give my input. I think it looks pretty good and doesn't get in the way of anything or make it look messy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I actually couldn't test it in action because currently when you use #275 (docker) trying to submit a post causes a 404 error, and as of the updates yesterday it seems that almost every page now results in an "Internal server error". It's just an html change so it *should* work, but making sure never hurts.

## Screenshots (if appropriate):
https://i.imgur.com/ABS4cFF.png

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
