### PR TITLE
Changes "deactivate" to "delete" and adds warnings about account deletion being irreversible

### DIFF
--- a/ruqqus/templates/announcements_modal.html
+++ b/ruqqus/templates/announcements_modal.html
@@ -22,8 +22,8 @@
           <div class="d-flex my-2">
             <img src="https://ruqqus.com/assets/images/icons/trash_gif.gif" class="mr-3" style="width: 25px; height: 100%;">
             <div>
-              <div class="h5 d-inline-block align-bottom">Account deactivation</div>
-              <p class="mb-0">Account deactivation is now a thing. Visit your security settings if you wish to deactivate your Ruqqus account. (We hope you don't though).</p>
+              <div class="h5 d-inline-block align-bottom">Account deletion</div>
+              <p class="mb-0">You can now delete your Ruqqus account. Visit your security settings if you wish to do this. (We hope you don't though).</p>
             </div>
           </div>
         </div>

--- a/ruqqus/templates/settings_security.html
+++ b/ruqqus/templates/settings_security.html
@@ -231,9 +231,9 @@
 
   <div class="body">
 
-    <label for="delete_account">Deactivate Account</label>
+    <label for="delete_account">Delete Account</label>
 
-    <p>This will permanently deactivate your Ruqqus Account.</p>
+    <p>This will permanently delete your Ruqqus Account. Be careful, this cannot be undone.</p>
 
   </div>
 
@@ -245,7 +245,7 @@
 
       <button class="btn btn-outline-danger ml-auto" id="delete_account_confirm"
       data-toggle="modal" data-target="#deleteAccountModal"
-      value="Delete Account">Deactivate Account</button>
+      value="Delete Account">Delete Account</button>
 
   </div>
 
@@ -269,7 +269,7 @@
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Deactivate your Ruqqus account</h5>
+        <h5 class="modal-title">Delete your Ruqqus account</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true"><i class="far fa-times"></i></span>
         </button>
@@ -320,7 +320,7 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-link text-muted" data-dismiss="modal">Cancel</button>
-            <input type="submit" id="deleteAccountBUtton" class="btn btn-danger" value="Deactivate my account"></button>
+            <input type="submit" id="deleteAccountBUtton" class="btn btn-danger" value="Delete my account"></button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I didn't really like how the setting to permanently delete your account is called "deactivate", so I changed it to say delete. Although "deactivate" is often interchangeable with "delete", on some websites they are different; "deactivate" can also mean temporarily disabling your account until you reactivate it. Any confusion whatsoever over this could have very serious consequences. I also added a warning in the delete account "danger zone" (at the bottom of the security settings page) that it can never be undone, to encourage people to think twice to make sure they want to go through with it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
As I said in my last pull request, I couldn't test it because the docker version is messed up right now and I can't run Ruqqus. But I didn't change anything but text, so it's safe to merge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
