### PR TITLE
Changed typo "pollack" to "polack"

### DIFF
--- a/ruqqus/assets/slurs.txt
+++ b/ruqqus/assets/slurs.txt
@@ -7,7 +7,7 @@ Kike
 Kraut
 Nigger
 Nignog/Niglet
-Pollack
+Polack
 Spic
 Towel/Rag Head
 Wetback


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed a typo. The anti-polish slur is actually spelled "Polack" (no extra l). "Pollack" is a type of fish, which could trigger false positives about the fish while possibly not blocking the actual slur.