### PR TITLE
Moves Trending above All on the sidebar, renames "All" to "New"

### DIFF
--- a/ruqqus/templates/sidebar-left.html
+++ b/ruqqus/templates/sidebar-left.html
@@ -29,23 +29,23 @@
               </a>
             </li>
             <li class="guild-recommendations-item">
-              <a href="/all?sort=new">
+              <a href="/all">
                 <div class="d-flex">
                   <div>
-                    <img src="/assets/images/icons/planet.png" class="profile-pic profile-pic-30"></div>
+                    <img src="/assets/images/icons/flame.png" class="profile-pic profile-pic-30"></div>
                     <div class="my-auto ml-2">
-                      <div class="text-black font-weight-normal">All</div>
+                      <div class="text-black font-weight-normal">Trending</div>
                     </div>
                   </div>
                 </a>
               </li>
               <li class="guild-recommendations-item">
-                <a href="/all">
+                <a href="/all?sort=new">
                   <div class="d-flex">
                     <div>
-                      <img src="/assets/images/icons/flame.png" class="profile-pic profile-pic-30"></div>
+                      <img src="/assets/images/icons/planet.png" class="profile-pic profile-pic-30"></div>
                       <div class="my-auto ml-2">
-                        <div class="text-black font-weight-normal">Trending</div>
+                        <div class="text-black font-weight-normal">New</div>
                       </div>
                     </div>
                   </a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On the left sidebar, I moved the "trending" button above "all", and renamed "all" to "new" (because that's what it is).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have always found it confusing that the first "All" button took me to new posts instead of hot ones. In order to look at those, I'd have to click on the trending button instead, which you don't see at first glance because it's the last button. To fix this I moved the "trending" button above the "all" button. I also renamed "all" to "new" so that it's clear that the button means *new* posts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This is a non-breaking change, I don't believe it needs testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
