### PR TITLE
Change z-index on .sticky-63 from 4 to 2, which fixes #422

### DIFF
--- a/ruqqus/assets/style/board_dark.scss
+++ b/ruqqus/assets/style/board_dark.scss
@@ -272,7 +272,7 @@ body.using-mouse :focus {
     top: 63px;
     height: auto;
     overflow-y: auto;
-    z-index: 4;
+    z-index: 2;
 }
 
 .sticky-105 {

--- a/ruqqus/assets/style/board_main.scss
+++ b/ruqqus/assets/style/board_main.scss
@@ -266,7 +266,7 @@ body.using-mouse :focus {
     top: 63px;
     height: auto;
     overflow-y: auto;
-    z-index: 4;
+    z-index: 2;
 }
 
 .sticky-105 {

--- a/ruqqus/assets/style/main.css
+++ b/ruqqus/assets/style/main.css
@@ -13360,7 +13360,7 @@ body.using-mouse :focus {
   top: 63px;
   height: auto;
   overflow-y: auto;
-  z-index: 4;
+  z-index: 2;
 }
 
 .sticky-105 {

--- a/ruqqus/assets/style/main.scss
+++ b/ruqqus/assets/style/main.scss
@@ -267,7 +267,7 @@ body.using-mouse :focus {
     top: 63px;
     height: auto;
     overflow-y: auto;
-    z-index: 4;
+    z-index: 2;
 }
 
 .sticky-105 {

--- a/ruqqus/assets/style/main_dark.css
+++ b/ruqqus/assets/style/main_dark.css
@@ -13782,7 +13782,7 @@ body.using-mouse :focus {
   top: 63px;
   height: auto;
   overflow-y: auto;
-  z-index: 4;
+  z-index: 2;
 }
 
 .sticky-105 {

--- a/ruqqus/assets/style/main_dark.scss
+++ b/ruqqus/assets/style/main_dark.scss
@@ -269,7 +269,7 @@ body.using-mouse :focus {
     top: 63px;
     height: auto;
     overflow-y: auto;
-    z-index: 4;
+    z-index: 2;
 }
 
 .sticky-105 {


### PR DESCRIPTION
I changed the z-index from 4 to 2

## Description
I fixed #422 as described in #422

## Motivation and Context
It fixes #422, a UI bug

## How Has This Been Tested?
I used Inspect Element. It was like one value.

## Screenshots (if appropriate):
Before:

![before](https://user-images.githubusercontent.com/1238820/91304864-04ffbe00-e75f-11ea-83da-064eca02f08f.png)

After:

![after](https://user-images.githubusercontent.com/1238820/91304907-16e16100-e75f-11ea-89a2-e8f0125ab3c7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
