### PR TITLE
Fix potential typo in API endpoint's path

### DIFF
--- a/ruqqus/routes/comments.py
+++ b/ruqqus/routes/comments.py
@@ -447,8 +447,8 @@ def delete_comment(cid, v):
 
 @app.route("/embed/comment/<cid>", methods=["GET"])
 @app.route("/embed/post/<pid>/comment/<cid>", methods=["GET"])
-@app.route("/api/vi/embed/comment/<cid>", methods=["GET"])
-@app.route("/api/vi/embed/post/<pid>/comment/<cid>", methods=["GET"])
+@app.route("/api/v1/embed/comment/<cid>", methods=["GET"])
+@app.route("/api/v1/embed/post/<pid>/comment/<cid>", methods=["GET"])
 def embed_comment_cid(cid, pid=None):
 
     comment=get_comment(cid)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces `vi` with `v1` in two API endpoints' paths.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In `comments.py`, two of the API endpoints have `vi` instead of `v1` in the path name; I believe that might be a typo. If I'm incorrect, feel free to close this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) [specifically, those apps which use `vi` paths; I don't think any exist at this point]

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
