### PR TITLE
nsfl and nsfw toggles on the API to use the update scope

### DIFF
--- a/ruqqus/routes/posts.py
+++ b/ruqqus/routes/posts.py
@@ -617,6 +617,7 @@ def embed_post_pid(pid):
 
 @app.route("/api/toggle_post_nsfw/<pid>", methods=["POST"])
 @is_not_banned
+@api("update")
 @validate_formkey
 def toggle_post_nsfw(pid, v):
 
@@ -636,6 +637,7 @@ def toggle_post_nsfw(pid, v):
 
 @app.route("/api/toggle_post_nsfl/<pid>", methods=["POST"])
 @is_not_banned
+@api("update")
 @validate_formkey
 def toggle_post_nsfl(pid, v):
 


### PR DESCRIPTION
Taking in account the comments of #434, the need of a edit API func is banished because it already exists, however the toggles on the post's NSFW and NSFL toggles (with API prefixes) should have scopes

## Description
Read above ^

## Motivation and Context
the update scope is not used too much, and toggling technically counts as update, so i guess that needing the update scope to update the NSFW/NSFL status of a post makes sense

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
