### PR TITLE
Change comment collapse sidebar color

### DIFF
--- a/ruqqus/assets/style/board_dark.scss
+++ b/ruqqus/assets/style/board_dark.scss
@@ -2636,7 +2636,7 @@ ul.comment-section {
     content: "";
     position: absolute;
     font-family: "Font Awesome 5 Pro";
-    border-left: 2px solid $gray-400;
+    border-left: 2px solid $gray-700;
     font-size: $font-size-base;
     color: $primary;
     display: inline-block;


### PR DESCRIPTION
Change the comment "collapse" sidebar color in dark mode

## Description
This pull request changes the the comment "collapse" sidebar color in dark mode to a more visually appealing dark grey, similar to the upvote and downvote buttons when they're not pressed.

## Motivation and Context
This isn't a *required* change, nor is it a crazy one to implement. That said, I find the current "collapse comment" color to be headache-inducing, and overall not fit with the rest of the UI.

## How has this been tested?
I tested the changes on Firefox 79.0, macOS 10.15.4, with the Inspector menu and, in the selector `.comment .comment-collapse::before`, I changed the value `#aaa` with `var(--gray-700)`, which is the equivalent of the Bootstrap SASS color `$gray-700` that I used in the code.

## Screenshots (if appropriate):
<img width="111" alt="Change comment collapse sidebar color" src="https://user-images.githubusercontent.com/20841500/92327313-04b5cb80-f059-11ea-8d3c-b80a3c16ad2d.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
