### PR TITLE
Permit localhost with explicit port to still be valid HTTP redirect for OAuth2

### DIFF
--- a/ruqqus/routes/oauth.py
+++ b/ruqqus/routes/oauth.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 from time import time
 import secrets
+import re
 
 from ruqqus.helpers.wrappers import *
 from ruqqus.helpers.base36 import *
@@ -60,7 +61,7 @@ def oauth_authorize_prompt(v):
     if not redirect_uri:
         return jsonify({"oauth_error":f"`redirect_uri` must be provided."}), 400
 
-    if redirect_uri.startswith('http://') and not urlparse(redirect_uri).netloc=="localhost":
+    if redirect_uri.startswith('http://') and not bool(re.match(r"^localhost(:\d+)?$", urlparse(redirect_uri).netloc=="localhost")):
         return jsonify({"oauth_error":"redirect_uri must not use http (use https instead)"}), 400
 
 

--- a/ruqqus/routes/oauth.py
+++ b/ruqqus/routes/oauth.py
@@ -61,7 +61,7 @@ def oauth_authorize_prompt(v):
     if not redirect_uri:
         return jsonify({"oauth_error":f"`redirect_uri` must be provided."}), 400
 
-    if redirect_uri.startswith('http://') and not bool(re.match(r"^localhost(:\d+)?$", urlparse(redirect_uri).netloc=="localhost")):
+    if redirect_uri.startswith('http://') and not bool(re.match(r"^localhost(:\d+)?$", urlparse(redirect_uri).netloc)):
         return jsonify({"oauth_error":"redirect_uri must not use http (use https instead)"}), 400
 
 

--- a/ruqqus/routes/oauth.py
+++ b/ruqqus/routes/oauth.py
@@ -61,7 +61,7 @@ def oauth_authorize_prompt(v):
     if not redirect_uri:
         return jsonify({"oauth_error":f"`redirect_uri` must be provided."}), 400
 
-    if redirect_uri.startswith('http://') and not bool(re.match(r"^localhost(:\d+)?$", urlparse(redirect_uri).netloc)):
+    if redirect_uri.startswith('http://') and not urlparse(redirect_uri).netloc.startswith("localhost"):
         return jsonify({"oauth_error":"redirect_uri must not use http (use https instead)"}), 400
 
 


### PR DESCRIPTION
Added a more detailed validation for OAuth2 redirects when the user chooses to use a custom port. It currently only checks if the `netloc` component of the URL is equal to `localhost`, but if a user has opted to use `http://localhost:3456/oauth/callback` it fails. as `netloc` is equal to `localhost:3456`.

## Description
I merely added a regular expression that also matches `localhost` and also optional trailing colon with one ore more numerical characters. The regular expression: `^localhost(:\d+)?$`

## Motivation and Context
Native applications who serve the redirect URL through `localhost` typically use a custom port when authenticating, and this exact scenario happened to me personally while developing a wrapper for this API. Without an explicit port it will work, and with one it fails with a 400 error and:

```json
{ "oauth_error":"redirect_uri must not use http (use https instead)` response." }
```

## How Has This Been Tested?
It is a simple regular expression, which I tested extensively with all manner of URIs in a Python REPL session. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
