### PR TITLE
Align bio lengths across codebase

### DIFF
--- a/ruqqus/templates/settings_profile.html
+++ b/ruqqus/templates/settings_profile.html
@@ -325,10 +325,10 @@
                     <div class="input-group mb-2">
                       <textarea class="form-control rounded" id="bio-text" aria-label="With textarea"
                       placeholder="Tell the Ruqqus community a bit about yourself."
-                      rows="3" name="bio" form="profile-settings" maxlength="300">{{ v.bio }}</textarea>
+                      rows="3" name="bio" form="profile-settings" maxlength="256">{{ v.bio }}</textarea>
                     </div>
                     <div class="d-flex">
-                      <small>Limit of 280 characters</small>
+                      <small>Limit of 256 characters</small>
                       <input class="btn btn-primary ml-auto" id="bioSave" type="submit" value="Save Changes">
                     </div>
                   </form>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Align bio lengths across codebase, as the backend only accepts the first 256 characters of the bio.

## Motivation and Context
This PR fixes an issue with the bio textarea in the Settings page. You can type up to 300 characters in there (as noted by the `maxlength="300"` attribute, but once you save, you'll only find the first 256 characters. Additionally the label underneath says you can only type 280 characters, which isn't the case. This PR unifies everything under the value the backend uses, which is 256.

## How Has This Been Tested?
Using the Inspector menu on Chromium 85.0.4183 and changing the `maxlength` attribute on the textarea from 300 to 256.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
