### PR TITLE
Adding missing comma which resulted in og:image and thumbnail meta tags being ignored

### DIFF
--- a/ruqqus/helpers/thumbs.py
+++ b/ruqqus/helpers/thumbs.py
@@ -63,7 +63,7 @@ def thumbnail_thread(pid):
 
         metas = ["ruqqus:thumbnail",
                  "twitter:image",
-                 "og:image"
+                 "og:image",
                  "thumbnail"
                  ]
 


### PR DESCRIPTION
After mentioning in discord that http://pathofexile.com wasn't getting a good thumbnail I decided to investigate why it ignored the og:image meta tag.

Without the comma python HELPFULLY concatenates the strings so it was checking for "og:imagethumbnail".