### PR TITLE
Authorize in settings-app for easier app authorization

### DIFF
--- a/ruqqus/templates/settings_apps.html
+++ b/ruqqus/templates/settings_apps.html
@@ -38,6 +38,10 @@
 				<input id="edit-{{ app.id }}-redirect" class="form-control" type="text" name="redirect_uri" value="{{ app.redirect_uri }}">
 				<label for="edit-{{ app.id }}-desc" class="mb-0 w-lg-25">Description</label>
 				<textarea form="edit-app-{{ app.id }}" class="form-control" name="description" id="edit-{{ app.id }}-desc" maxlength="256">{{ app.description }}</textarea>
+				
+		    		<label for="edit-{{ app.id }}-scope" class="mb-0 w-lg-25">Scopes</label>
+				<input id="edit-{{ app.id }}-scopes" class="form-control" type="text" name="name" value=""></br>
+				<a href="javascript:void(0)" class="btn btn-primary ml-2" onclick="let e=document.getElementById('edit-{{ app.id }}-scopes');window.location.replace('/oauth/authorize?client_id={{ app.client_id }}&client_secret={{ app.client_secret }}&redirect_uri={{ app.redirect_uri }}&state=ruqqus&permanent=true&scope='+e.value)">Authorize</a>
 			</div>
 		</div>
 		<div class="footer">


### PR DESCRIPTION
easier authorization for us, api developers

## Description
just added a button and a scopes label

## Motivation and Context
its too hard for us to make manual requests to oauth/authorize

## How Has This Been Tested?
locla server and works 100%

## Screenshots (if appropriate):
![Screenshot from 2020-09-27 10-29-37](https://user-images.githubusercontent.com/39974089/94367388-68597480-00ac-11eb-80d0-9a9864908c9a.png)
![Screenshot from 2020-09-27 10-29-28](https://user-images.githubusercontent.com/39974089/94367389-68f20b00-00ac-11eb-8081-fd0177cd4827.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
