### PR TITLE
User by uid to redirect to actual user api endpoint (so we can query users by their Id in API)

### DIFF
--- a/ruqqus/routes/users.py
+++ b/ruqqus/routes/users.py
@@ -59,7 +59,20 @@ def user_uid(uid):
     else:
         abort(404)
 
-
+# Allow Id of user to be queryied, and then redirect the bot to the
+# actual user api endpoint.
+# So they get the data and then there will be no need to reinvent
+# the wheel.
+@app.route("/api/v1/user/by_id/<uid>", methods=["GET"])
+@auth_desired
+@api("read")
+def user_by_uid(uid, v=None):
+    user=g.db.query(User).filter_by(id=base36decode(uid)).first()
+    if user == None:
+      abort(404)
+    
+    return redirect(f"/api/v1/user/{user.username}")
+        
 @app.route("/u/<username>", methods=["GET"])
 def redditor_moment_redirect(username):
 


### PR DESCRIPTION
ref: https://discord.com/channels/599258778520518676/679721002795532422/765172020194967553

<!--- Provide a general summary of your changes in the Title above -->
Querying users in API currently works like <username>, current endpoint (/uid/uid) only redirects to user-land pages, but this endpoint redirects to the actual user API endpoint. (/api/v1/)

## Description
<!--- Describe your changes in detail -->

Obtain user info by Id.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Maybe ruqqus-metrics can benefit of this so it can count new registered users because id is incremental base36

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on local enviroment (it works)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
