### PR TITLE
fix blocked/blocking in visible comments being switched around

### DIFF
--- a/ruqqus/templates/comments.html
+++ b/ruqqus/templates/comments.html
@@ -101,10 +101,10 @@
         {% if c.is_bot %}
         <i class="fad fa-robot text-info" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="Automaton"></i>
         {% endif %}
-        {% if c.is_blocked %}
+        {% if c.is_blocking %}
         <i class="fas fa-user-minus text-warning" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="You're blocking this user, but you can see this comment because it's in your guild."></i>
         {% endif %}
-        {% if c.is_blocking %}
+        {% if c.is_blocked %}
         <i class="fas fa-user-minus text-danger" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="This user is blocking you, but you can see this comment because it's in your guild."></i>
         {% endif %}
         <span class="time-stamp"> · {{ c.age_string }}</span>{% if standalone and c.parent_submission and c.post.board.is_private and not c.post.post_public %} · <i class="fas fa-eye-slash text-muted" data-toggle="tooltip" data-placement="bottom" title="Private content, visible because {{ c.visibility_reason(v) }}"></i>{% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a bug where the "you are blocked by this user" and "you are blocking this user" labels in visible comments were switched around (and therefore could appear that one is blocking another user, while instead they are blocked by them).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
