### PR TITLE
Fix possible flaw when sieging a guild

### DIFF
--- a/ruqqus/routes/boards.py
+++ b/ruqqus/routes/boards.py
@@ -1195,8 +1195,13 @@ def siege_guild(v):
     # skip any deleted mod
     mods = []
     for user in guild.mods:
+        
         if user.id == v.id:
-            break
+            return render_template("message.html",
+                                   v=v,
+                                   title=f"Siege against +{guild.name} Failed",
+                                   error="You are already a guildmaster of +{guild.name}."
+                                   ), 403
         if not (user.is_banned and user.unban_utc ==
                 0) and not user.is_deleted:
             mods.append(user)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The current logic goes like this

```python
# blah blah blah

for each mod in guild.mod do
  if user.id == v.id
    break
  # do blah blah blah, append to list
endfor

# blah blah blah
```

The problem, is that if the mod array is structured as ['User1','User2','User3']. So, if you are User1, the rest of the mods are not appended, thus allowing you to siege a guild regardless if they were active or not, because the mods are not checked.

Note: Mods are removed from the guild, so one can obliterate the entire guild mods

The fix to this is to not allow users that are already mods to siege.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It solves a potential flaw.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

taking the logic and doing a simple test (with array, same logic)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
