### PR TITLE
Remove vote API endpoints since bots should not vote

### DIFF
--- a/ruqqus/routes/votes.py
+++ b/ruqqus/routes/votes.py
@@ -10,7 +10,6 @@ from flask import *
 from ruqqus.__main__ import app
 
 
-@app.route("/api/v1/vote/post/<post_id>/<x>", methods=["POST"])
 @app.route("/api/vote/post/<post_id>/<x>", methods=["POST"])
 #@is_not_banned
 @auth_required
@@ -72,7 +71,6 @@ def api_vote_post(post_id, x, v):
     return make_response(""), 204
 
 
-@app.route("/api/v1/vote/comment/<comment_id>/<x>", methods=["POST"])
 @app.route("/api/vote/comment/<comment_id>/<x>", methods=["POST"])
 @is_not_banned
 @api("vote")


### PR DESCRIPTION
Title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://ruqqus.com/help/rules

This says:
Bots may not vote.
But we still have the vote endpoints
Then just remove them, if bots are not going to use them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Not tested, but should work

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
