### PR TITLE
prevent bots from voting

### DIFF
--- a/ruqqus/routes/votes.py
+++ b/ruqqus/routes/votes.py
@@ -21,6 +21,10 @@ def api_vote_post(post_id, x, v):
     if x not in ["-1", "0", "1"]:
         abort(400)
 
+    # disallow bots
+    if request.headers.get("X-User-Type","") == "Bot":
+        abort(403)
+
     x = int(x)
 
     post = get_post(post_id)
@@ -81,6 +85,10 @@ def api_vote_comment(comment_id, x, v):
 
     if x not in ["-1", "0", "1"]:
         abort(400)
+
+    # disallow bots
+    if request.headers.get("X-User-Type","") == "Bot":
+        abort(403)
 
     x = int(x)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR prevents (obvious) bots from accessing `/api/v1/vote` endpoints

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In Discord discussion surrounding #505, @ax3cutor suggested to 403 incoming voting API requests from bots, instead of removing the API endpoints completely. This PR does exactly that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't been tested, but should work.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) (specifically, API libraries which have vote API methods, but have the bot header set by default, e.g. @acikek's `ruqqus-js`)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
