### PR TITLE
Remove enviroment variable errors for giphy, aws and hcaptcha, we dont use enviro in local instances, so put a placeholder instead of an error when no enviroment variable is given

### DIFF
--- a/ruqqus/__main__.py
+++ b/ruqqus/__main__.py
@@ -74,9 +74,9 @@ else:
 app.config["CACHE_DIR"] = environ.get("CACHE_DIR", "ruqquscache")
 
 # captcha configs
-app.config["HCAPTCHA_SITEKEY"] = environ.get("HCAPTCHA_SITEKEY")
+app.config["HCAPTCHA_SITEKEY"] = environ.get("HCAPTCHA_SITEKEY","")
 app.config["HCAPTCHA_SECRET"] = environ.get(
-    "HCAPTCHA_SECRET").lstrip().rstrip()
+    "HCAPTCHA_SECRET","").lstrip().rstrip()
 
 # antispam configs
 app.config["SPAM_SIMILARITY_THRESHOLD"] = float(

--- a/ruqqus/helpers/aws.py
+++ b/ruqqus/helpers/aws.py
@@ -7,8 +7,8 @@ from urllib.parse import urlparse
 from PIL import Image
 
 BUCKET = "i.ruqqus.com"
-CF_KEY = environ.get("CLOUDFLARE_KEY").lstrip().rstrip()
-CF_ZONE = environ.get("CLOUDFLARE_ZONE")
+CF_KEY = environ.get("CLOUDFLARE_KEY","").lstrip().rstrip()
+CF_ZONE = environ.get("CLOUDFLARE_ZONE","")
 
 # setup AWS connection
 S3 = boto3.client("s3",

--- a/ruqqus/routes/giphy.py
+++ b/ruqqus/routes/giphy.py
@@ -4,7 +4,7 @@ import requests
 
 from ruqqus.__main__ import app
 
-GIPHY_KEY = environ.get('GIPHY_KEY').rstrip()
+GIPHY_KEY = environ.get("GIPHY_KEY","").rstrip()
 
 
 @app.route("/giphy", methods=["GET"])


### PR DESCRIPTION
Enviroment variables, solves a little of headcache when deploying to docker or somewhere else, and also allows us local host ppl to concern on code more rather than on some nice looking enviroment variables

## Motivation and Context
No more errors, no more enviroment variable exports, everyone with a local instance will be happy

## How Has This Been Tested?
i tested it and i was going to make a PR but then github decided to be github and i had to make all commits by hand, they should work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
