### PR TITLE
Fix break statement causing a wipe of board.mods

### DIFF
--- a/ruqqus/routes/boards.py
+++ b/ruqqus/routes/boards.py
@@ -1199,7 +1199,11 @@ def siege_guild(v):
     mods = []
     for user in guild.mods:
         if user.id == v.id:
-            break
+            return render_template("message.html",
+                                   v=v,
+                                   title=f"Siege against +{guild.name} Failed",
+                                   error="Your siege failed. You are already guildmaster of this guild."
+                                   ), 403
         if not (user.is_banned and user.unban_utc ==
                 0) and not user.is_deleted:
             mods.append(user)


### PR DESCRIPTION
title

## Motivation and Context
it prevents certain funky stuff from happening due to the order of mods on the board table

## How Has This Been Tested?
not tested, but logic was tested on interpreted python and it results on every record being deleted

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
