### PR TITLE
Add noopener to outgoing links

### DIFF
--- a/ruqqus/templates/submission.html
+++ b/ruqqus/templates/submission.html
@@ -541,7 +541,7 @@
 
     <div class="row no-gutters d-block d-md-none">
       <div class="col">
-       <a target="_blank" href="{{ p.url }}">{% if p.is_image and p.domain_obj and p.domain_obj.show_thumbnail %}<img src="{{ p.url }}" class="img-fluid" alt="Unable to anonymously load image">
+       <a target="_blank" rel="noopener noreferrer" href="{{ p.url }}">{% if p.is_image and p.domain_obj and p.domain_obj.show_thumbnail %}<img src="{{ p.url }}" class="img-fluid" alt="Unable to anonymously load image">
          <div class="post-img-overlay d-block d-md-none">{{ p.domain }}<i class="fas fa-external-link-alt text-small ml-2"></i></div>
          {% endif %}
        </a>


### PR DESCRIPTION
The HTML link that opens in a new tab/window allows the target page to access the DOM of the origin page using ```window.opener``` unless link type ```noopener``` or ```noreferrer``` is specified. This is potentially a security risk.