### PR TITLE
Added links to guild's moderation log in sidebar and modal

### DIFF
--- a/ruqqus/templates/board.html
+++ b/ruqqus/templates/board.html
@@ -59,6 +59,10 @@
       <small class="text-muted">No guildmasters</small>
       {% endfor %}
     </div>
+    <div class="text-small font-weight-bold text-muted text-uppercase mb-3" style="letter-spacing: 0.025rem;">Moderation Log</div>
+    <div class="d-flex align-items-center">
+      <a href="https://ruqqus.com/{{ b.name }}/mod/log">Moderation Log</a>
+    </div>
     {% if b.show_settings_icons %}
     <div class="text-small font-weight-bold text-muted text-uppercase mb-2 mt-3" style="letter-spacing: 0.025rem;">Settings</div>
     <div class="text-primary">

--- a/ruqqus/templates/guild_details_modal.html
+++ b/ruqqus/templates/guild_details_modal.html
@@ -33,7 +33,7 @@
           <div class="font-weight-bold text-small text-uppercase text-muted mb-1" style="letter-spacing: 0.025rem;">Members</div>
           <div>{{ board.subscriber_count }}</div>
         </div>
-
+    
       {% if v %}
       <div id="button-sub-modal" {% if board.has_subscriber(v) %}class="d-none"{% endif %}><a class="btn btn-primary" href="javascript:void(0)" onclick="post('/api/subscribe/{{ board.name }}', callback=toggleSub)">Join guild</a></div>
       <div id="button-unsub-modal" {% if not board.has_subscriber(v) %}class="d-none"{% endif %}><a class="btn btn-secondary" href="javascript:void(0)" onclick="post('/api/unsubscribe/{{ board.name }}', callback=toggleSub)">Leave</a></div>
@@ -49,7 +49,14 @@
         {{ board.description_html | safe }}
 
       </div>
-
+      <div class="p-3">
+        
+        <div class="h6">Mod Log</div>
+        
+        <a href="https://ruqqus.com/{{ board.name }}/mod/log">Moderation Log</a>
+        
+      </div>
+      </div>
 <!-- hide rules thingy
       <div class="p-3">
 


### PR DESCRIPTION
I have added new sections with the link to the guild's moderation log in both the guild's sidebar and the modal.

## Description
I have added new sections with the link to the guild's moderation log in both the guild's sidebar and the modal.

## Motivation and Context
It solves the problem of users not being able to easily access the moderation log without having to type in a specific URL.

## How Has This Been Tested?
I have not tested this, but the variable names match those referenced in these and other files, and the URL structure is functional when tried, so I am confident this will work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
