### PR TITLE
Fixed "No, back to ruqqus" button still authorizing the app

### DIFF
--- a/ruqqus/templates/oauth.html
+++ b/ruqqus/templates/oauth.html
@@ -33,7 +33,7 @@
         <input type="hidden" name="state" value="{{ state }}">
 
         <input type="submit" class="btn btn-primary" id="auth_button" value="Authorize {{ application.app_name }}">
-         <a href="/" class="btn btn-secondary">No, back to Ruqqus</a>
+        <a href="/" class="btn btn-secondary">No, back to Ruqqus</a>
 
     </form>
 

--- a/ruqqus/templates/oauth.html
+++ b/ruqqus/templates/oauth.html
@@ -33,7 +33,7 @@
         <input type="hidden" name="state" value="{{ state }}">
 
         <input type="submit" class="btn btn-primary" id="auth_button" value="Authorize {{ application.app_name }}">
-        <a href="/"><button class="btn btn-secondary">No, back to Ruqqus</button></a>
+         <a href="/" class="btn btn-secondary">No, back to Ruqqus</a>
 
     </form>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed `<button>` tags from "No, back to Ruqqus" link, they were causing an issue
The button still looks the same

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
"No, back to ruqqus" would lead to authorizing the app, instead of going back to ruqqus frontpage

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on a local instance. Works as expected

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
