### PR TITLE
Update all mentions of 2020 Ruqqus

### DIFF
--- a/docs/errors/503.html
+++ b/docs/errors/503.html
@@ -146,7 +146,7 @@
             <li class="list-inline-item"><a href="/help/donate" target="_blank">Donate</a></li>
             <li class="list-inline-item"><a href="https://www.twitter.com/ruqqus" target="_blank">Twitter</a></li>
             <li class="list-inline-item"><a href="https://github.com/ruqqus/ruqqus" target="_blank">Github</a></li>
-            <li class="list-inline-item">&copy; 2020 Ruqqus, LLC</li>
+            <li class="list-inline-item">&copy; 2021 Ruqqus, LLC</li>
           </ul>
         </div>
         </div>

--- a/docs/errors/maintenance.html
+++ b/docs/errors/maintenance.html
@@ -123,7 +123,7 @@
             <li class="list-inline-item"><a href="/help/donate" target="_blank">Donate</a></li>
             <li class="list-inline-item"><a href="https://www.twitter.com/ruqqus" target="_blank">Twitter</a></li>
             <li class="list-inline-item"><a href="https://github.com/ruqqus/ruqqus" target="_blank">Github</a></li>
-            <li class="list-inline-item">&copy; 2020 Ruqqus, LLC</li>
+            <li class="list-inline-item">&copy; 2021 Ruqqus, LLC</li>
           </ul>
         </div>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,7 +144,7 @@
             <li class="list-inline-item"><a href="https://paypal.me/ruqqus" target="_blank">Donate</a></li>
             <li class="list-inline-item"><a href="https://www.twitter.com/ruqqus" target="_blank">Twitter</a></li>
             <li class="list-inline-item"><a href="https://github.com/ruqqus/ruqqus" target="_blank">Github</a></li>
-            <li class="list-inline-item">&copy; 2020 Ruqqus, LLC</li>
+            <li class="list-inline-item">&copy; 2021 Ruqqus, LLC</li>
           </ul>
         </div>
         </div>

--- a/ruqqus/templates/email/default.html
+++ b/ruqqus/templates/email/default.html
@@ -472,7 +472,7 @@
                 <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
                   <tr>
                     <td class="content-cell" align="center">
-                      <p class="f-fallback sub align-center">&copy; 2020 Ruqqus, LLC. All rights reserved.</p>
+                      <p class="f-fallback sub align-center">&copy; 2021 Ruqqus, LLC. All rights reserved.</p>
                       <p class="f-fallback sub align-center">
                         Ruqqus, LLC<br>
                         300 Delaware Ave.<br>

--- a/ruqqus/templates/email/mailing.html
+++ b/ruqqus/templates/email/mailing.html
@@ -9,7 +9,7 @@
 
 Hey there, {{ user.username }}
 
-Thanks for using Ruqqus. We're updating the terms of service to cover some rules about new features that have recently been added to Ruqqus. These changes go into effect tomorrow, 28 December 2020.
+Thanks for using Ruqqus. We're updating the terms of service to cover some rules about new features that have recently been added to Ruqqus. These changes go into effect tomorrow, 28 December 2021.
 
 1. Guild categorization - Guildmasters may not deliberately miscategorize their Guilds. Ruqqus is based on the premise that *you* should decide what you want to see, and accurate Guild categorizations are essential to that.
 

--- a/ruqqus/templates/errors/503.html
+++ b/ruqqus/templates/errors/503.html
@@ -115,7 +115,7 @@
             <li class="list-inline-item"><a href="/help/donate" target="_blank">Donate</a></li>
             <li class="list-inline-item"><a href="https://www.twitter.com/ruqqus" target="_blank">Twitter</a></li>
             <li class="list-inline-item"><a href="https://github.com/ruqqus/ruqqus" target="_blank">Github</a></li>
-            <li class="list-inline-item">&copy; 2020 Ruqqus, LLC</li>
+            <li class="list-inline-item">&copy; 2021 Ruqqus, LLC</li>
           </ul>
         </div>
         </div>

--- a/ruqqus/templates/footer.html
+++ b/ruqqus/templates/footer.html
@@ -13,6 +13,6 @@
         </ul>
 
 
-        <div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2020 Ruqqus, LLC</div>
+        <div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2010 Ruqqus, LLC</div>
 
       </div>

--- a/ruqqus/templates/footer_article.html
+++ b/ruqqus/templates/footer_article.html
@@ -53,7 +53,7 @@
 </div>
 <div class="row">
     <div class="col">
-        <span class="text-white text-small-extra opacity-50">&copy; 2020 Ruqqus, LLC</span>
+        <span class="text-white text-small-extra opacity-50">&copy; 2021 Ruqqus, LLC</span>
     </div>
 </div>
 </div>

--- a/ruqqus/templates/footer_bottom.html
+++ b/ruqqus/templates/footer_bottom.html
@@ -12,6 +12,6 @@
       <li class="list-inline-item"><a href="/discord" class="text-gray-500">Discord</a></li>
     </ul>
 
-    <div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2020 Ruqqus, LLC</div>
+    <div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2010 Ruqqus, LLC</div>
 
   </footer>

--- a/ruqqus/templates/help/donate.html
+++ b/ruqqus/templates/help/donate.html
@@ -472,7 +472,7 @@
 	</div>
 	<div class="row">
 		<div class="col">
-			<span class="text-white text-small-extra opacity-50">&copy; 2020 Ruqqus, LLC</span>
+			<span class="text-white text-small-extra opacity-50">&copy; 2021 Ruqqus, LLC</span>
 		</div>
 	</div>
 </div>

--- a/ruqqus/templates/make_board.html
+++ b/ruqqus/templates/make_board.html
@@ -139,7 +139,7 @@
                         <li class="list-inline-item"><a href="https://github.com/ruqqus/ruqqus" class="text-gray-500">Github</a></li>
                         <li class="list-inline-item"><a href="/discord" class="text-gray-500">Discord</a></li>
                     </ul>
-                    <div class="text-muted text-small-extra mt-1">v. 2.5.0, © 2020 Ruqqus, LLC</div>
+                    <div class="text-muted text-small-extra mt-1">v. 2.5.0, © 2010 Ruqqus, LLC</div>
                 </div>
 
             </div>

--- a/ruqqus/templates/submit.html
+++ b/ruqqus/templates/submit.html
@@ -210,7 +210,7 @@
 							<li class="list-inline-item"><a href="/discord" class="text-gray-500">Discord</a></li>
 						</ul>
 
-						<div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2020 Ruqqus, LLC</div>
+						<div class="text-muted text-small-extra mt-1">v. 2.29.9.9, © 2010 Ruqqus, LLC</div>
 
 					</div>
 


### PR DESCRIPTION
Updates all instances of this

![image](https://user-images.githubusercontent.com/32943174/104638592-5d831980-5674-11eb-8077-989d59a7fd08.png)


## Description
The year is 2021, so Ruqqus pages should now say  © 2021 Ruqqus, LLC

## Motivation and Context
I want to get The Codesmith badge, and I still can't set up Ruqqus on Linux cus the Alembic PR or whatever wasn't merged, so I gotta start somewhere

## How Has This Been Tested?
`grep` on the project no longer returns any 2020 LLC references

## Screenshots (if appropriate):
[Grep screenshot](https://i.imgur.com/1rwXU8W.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
