### PR TITLE
Fixes account deletion bug

### DIFF
--- a/ruqqus/routes/settings.py
+++ b/ruqqus/routes/settings.py
@@ -395,8 +395,7 @@ def update_announcement(v):
 
 
 @app.route("/settings/delete_account", methods=["POST"])
-@is_not_banned
-@no_negative_balance("html")
+@auth_required
 @validate_formkey
 def delete_account(v):
 


### PR DESCRIPTION
Some users were complaining about not being able to delete their accounts, and it appears that there was an oversight where suspended accounts and users without ruqqus premium are prevented from doing so. The former was fixed in #589 along with other account settings functions but somehow got reintroduced here along with the premium check. Account deletion is also missing `auth_required` now, which *shouldn't* be an issue as it depends on the logged-in user `v` in the first place but just in case and for consistency I restored it.