### PR TITLE
Don't return additional data for deleted accounts.

### DIFF
--- a/ruqqus/classes/user.py
+++ b/ruqqus/classes/user.py
@@ -895,7 +895,7 @@ class User(Base, Stndrd, Age_times):
     def json(self):
         data= self.json_core
 
-        if self.is_suspended or self.is_banned:
+        if self.is_suspended or self.is_deleted:
             return data
 
         data["badges"]=[x.json_core for x in self.badges]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes API returning additional data for deleted profiles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The API returns `post_count`, `comment_count`, `post_rep`, `comment_rep` and `badges` in the response for deleted profiles. This is clearly unintentional.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
