### PR TITLE
Remove block button if comment belongs to deactivated user

### DIFF
--- a/ruqqus/templates/comments.html
+++ b/ruqqus/templates/comments.html
@@ -274,7 +274,7 @@
               {% endif %}
         {% endif %}
 
-            {% if v and not v.id==c.author_id %}
+            {% if v and not v.id==c.author_id and not c.author.is_deleted %}
             <a class="dropdown-item text-danger" href="javascript:void(0)" onclick="post_toast('/settings/block?username={{ c.author.username }}')"
             ><i class="fas fa-user-slash text-danger fa-fw"></i>Block user</a>
             {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the block button if the comment belongs to a deleted account

## Motivation and Context
Prevents usernames from being leaked from recently (90d) deactivated accounts

## How Has This Been Tested?
Untested, but shouldn't have any issues

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
