### PR TITLE
Banido's Quality of Life package-01

### DIFF
--- a/ruqqus/assets/js/all_js.js
+++ b/ruqqus/assets/js/all_js.js
@@ -314,7 +314,26 @@ function collapse_comment(comment_id) {
 
 };
 
-//Commenting form
+// Text Area Input handling
+
+function textAreaOnKeyDown(e, func){
+  if (isCtrlEnterSubmit(e))
+    func();
+
+  return;
+}
+
+function isCtrlEnterSubmit(e) {
+  // If the user has pressed enter + ctrl/command
+  if ((e.keyCode == 10 || e.keyCode == 13) && (e.ctrlKey || e.metaKey))
+  {
+     return true;
+  }
+  
+  return false;
+}
+
+// Commenting form
 
 // Expand comment box on focus, hide otherwise
 

--- a/ruqqus/templates/comments.html
+++ b/ruqqus/templates/comments.html
@@ -144,7 +144,7 @@
       <div id="comment-edit-{{ c.base36id }}" class="d-none comment-write collapsed child">
        <form id="comment-edit-form-{{ c.base36id }}" action="/edit_comment/{{ c.base36id }}" method="post" class="input-group">
         <input type="hidden" name="formkey" value="{{ v.formkey }}">
-        <textarea id="comment-edit-body-{{ c.base36id }}" name="body" form="comment-edit-form-{{ c.base36id }}" class="comment-box form-control rounded" id="edit-box-comment-{{ c.base36id }}" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{ c.body }}</textarea> 
+        <textarea id="comment-edit-body-{{ c.base36id }}" name="body" form="comment-edit-form-{{ c.base36id }}" class="comment-box form-control rounded" id="edit-box-comment-{{ c.base36id }}" onkeydown="textAreaOnKeyDown(event, (id = '{{ c.base36id }}') => comment_edit(id))" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{ c.body }}</textarea> 
         <div class="comment-format"> 
          <small class="format pl-0"><i class="fas fa-bold" aria-hidden="true" onclick="makeBold('comment-edit-body-{{ c.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Bold"></i></small> 
          <small class="format"><i class="fas fa-italic" aria-hidden="true" onclick="makeItalics('comment-edit-body-{{ c.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Italicize"></i></small> 
@@ -341,7 +341,7 @@
         <input type="hidden" name="formkey" value="{{ v.formkey }}"> 
         <input type="hidden" name="parent_fullname" value="{{ c.fullname }}"> 
         <input id="reply-form-submission-{{ c.fullname }}" type="hidden" name="submission" value="{{ c.post.base36id }}"> 
-        <textarea name="body" form="reply-to-t3_{{ c.base36id }}" class="comment-box form-control rounded" id="reply-form-body-{{ c.fullname }}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea> 
+        <textarea name="body" form="reply-to-t3_{{ c.base36id }}" class="comment-box form-control rounded" id="reply-form-body-{{ c.fullname }}" onkeydown="textAreaOnKeyDown(event, (fullname = '{{ c.fullname }}') => post_comment(fullname))" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea> 
         <div class="comment-format" id="comment-format-bar-{{ c.base36id }}"> 
           <small class="format pl-0">
             <i class="fas fa-bold" aria-hidden="true" onclick="makeBold('reply-form-body-{{ c.fullname }}')" data-toggle="tooltip" data-placement="bottom" title="Bold"></i>

--- a/ruqqus/templates/search.html
+++ b/ruqqus/templates/search.html
@@ -156,11 +156,15 @@
 
     <div class="col-12">
 
+      {% block listing_template %}
+      
       <div class="posts" id="posts">
 
-        {% block listing_template %}{% include "submission_listing.html" %}{% endblock %}
-
+        {% include "submission_listing.html" %}
+    
       </div>
+
+      {% endblock %}
     </div>
   </div>
 

--- a/ruqqus/templates/submission.html
+++ b/ruqqus/templates/submission.html
@@ -488,7 +488,7 @@
             <form id="post-edit-form-{{ p.base36id }}" action="/edit_post/{{ p.base36id }}" method="post" class="input-group">
               <input type="hidden" name="formkey" value="{{ v.formkey }}">
               <input type="hidden" name="current_page" value="{{ request.path }}">
-              <textarea name="body" id="post-edit-box-{{ p.base36id }}" form="post-edit-form-{{ p.base36id }}" class="comment-box form-control rounded" onkeydown="textAreaOnKeyDown(event, (id = '{{ p.base36id }}') => togglePostEdit(id))" aria-label="With textarea" placeholder="Add text to your post..." rows="3">{{ p.body }}</textarea> 
+              <textarea name="body" id="post-edit-box-{{ p.base36id }}" form="post-edit-form-{{ p.base36id }}" class="comment-box form-control rounded" onkeydown="textAreaOnKeyDown(event, ()=>{document.getElementById('post-edit-form-{{ p.base36id }}').submit()})" aria-label="With textarea" placeholder="Add text to your post..." rows="3">{{ p.body }}</textarea> 
               <div class="comment-format"> 
                 <small class="format pl-0"><i class="fas fa-bold" aria-hidden="true" onclick="makeBold('post-edit-box-{{ p.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Bold"></i></small> 
                 <small class="format"><i class="fas fa-italic" aria-hidden="true" onclick="makeItalics('post-edit-box-{{ p.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Italicize"></i></small> 

--- a/ruqqus/templates/submission.html
+++ b/ruqqus/templates/submission.html
@@ -488,7 +488,7 @@
             <form id="post-edit-form-{{ p.base36id }}" action="/edit_post/{{ p.base36id }}" method="post" class="input-group">
               <input type="hidden" name="formkey" value="{{ v.formkey }}">
               <input type="hidden" name="current_page" value="{{ request.path }}">
-              <textarea name="body" id="post-edit-box-{{ p.base36id }}" form="post-edit-form-{{ p.base36id }}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="3">{{ p.body }}</textarea> 
+              <textarea name="body" id="post-edit-box-{{ p.base36id }}" form="post-edit-form-{{ p.base36id }}" class="comment-box form-control rounded" onkeydown="textAreaOnKeyDown(event, (id = '{{ p.base36id }}') => togglePostEdit(id))" aria-label="With textarea" placeholder="Add text to your post..." rows="3">{{ p.body }}</textarea> 
               <div class="comment-format"> 
                 <small class="format pl-0"><i class="fas fa-bold" aria-hidden="true" onclick="makeBold('post-edit-box-{{ p.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Bold"></i></small> 
                 <small class="format"><i class="fas fa-italic" aria-hidden="true" onclick="makeItalics('post-edit-box-{{ p.base36id }}')" data-toggle="tooltip" data-placement="bottom" title="Italicize"></i></small> 
@@ -722,7 +722,7 @@
       <input type="hidden" name="parent_fullname" value="t2_{{ p.base36id }}">
       <input id="reply-form-submission-{{ p.fullname }}" type="hidden" name="submission" value="{{ p.base36id }}">
       {% if v %}
-      <textarea id="reply-form-body-{{ p.fullname }}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{ p.fullname }}" aria-label="With textarea" placeholder="Add your comment..." rows="1"></textarea>
+      <textarea id="reply-form-body-{{ p.fullname }}" class="comment-box form-control rounded" id="comment-form" onkeydown="textAreaOnKeyDown(event, (fullname = '{{ p.fullname }}') => post_comment(fullname))" name="body" form="reply-to-{{ p.fullname }}" aria-label="With textarea" placeholder="Add your comment..." rows="1"></textarea>
       {% endif %}
       <div class="comment-format">
         <small class="format pl-0"><i class="fas fa-bold" onclick="makeBold('reply-form-body-{{ p.fullname }}')" data-toggle="tooltip" data-placement="bottom" data-delay='{"show":"700", "hide":"300"}' title="Bold"></i></small>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add ctrl+enter submission to comments, comment edits, and submission to post edits.  
Fix user and guild search listings style. (when searched for they were being displayed as posts).

## Motivation and Context

Felt like

## How Has This Been Tested?

Local machine. Firefox and Chrome.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [ X] My code follows the code style of this project.

## Before, notice borders: 

<img width="1440" alt="imagem" src="https://user-images.githubusercontent.com/75697524/123181493-5400a780-d485-11eb-8eb2-771889e28b4a.png">

<img width="1440" alt="imagem" src="https://user-images.githubusercontent.com/75697524/123181531-60850000-d485-11eb-84b4-123c671d8da6.png">


## After:

<img width="1440" alt="imagem" src="https://user-images.githubusercontent.com/75697524/123181440-34697f00-d485-11eb-830f-28d6be4d20cf.png">

<img width="1440" alt="imagem" src="https://user-images.githubusercontent.com/75697524/123181561-6c70c200-d485-11eb-8ae8-e39618540233.png">


(no images for ctrl/cmd + enter)
