### PR TITLE
Add class names for pins / heralds

### DIFF
--- a/ruqqus/templates/comments.html
+++ b/ruqqus/templates/comments.html
@@ -19,7 +19,7 @@
 
     <div class="comment-body">
 
-        <div id="comment-{{ c.base36id }}-only" class="{% if c.gm_distinguish %}heralded{% endif %}">
+        <div id="comment-{{ c.base36id }}-only" class="">
 
             <div class="user-info">{% if standalone and c.over_18 %}<span class="badge badge-danger">NSFW</span> {% endif %}
                 [{% if c.is_banned %}Removed by administrators{% elif c.deleted_utc > 0 %}Deleted by author{% elif c.is_blocking %}You are blocking @{{ c.author.username }}{% elif c.is_blocked %}This user has blocked you{% endif %}]
@@ -94,7 +94,7 @@
 
   <div class="comment-body">
 
-    <div id="comment-{{ c.base36id }}-only" class="{% if c.is_banned %} banned{% endif %}{% if c.deleted_utc  %} deleted{% endif %}">
+    <div id="comment-{{ c.base36id }}-only" class="{{ 'banned ' if c.is_banned }}{{ 'deleted ' if c.deleted_utc }}{{ 'pinned ' if c.is_pinned }}{{ 'heralded' if c.gm_distinguish }}">
 
       <div class="user-info">{% if standalone and c.over_18 %}<span class="badge badge-danger text-small-extra mr-1">nsfw</span> {% endif %} {% if c.is_pinned %}<i class="text-info fas fa-thumbtack fa-rotate--45" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="Pinned comment"></i> · {% endif %} {% if c.author.is_deleted %}[deleted account]{% else %}<a href="/@{{ c.author.username }}" class="user-name {% if c.is_op %}text-info{% endif %}"><img src="{{ c.author.profile_url }}" class="d-md-inline d-none profile-pic-25 mr-2"/><span class="user-name-inner">{{ c.author.username }}</span></a>{% if c.title %}{{ c.title.rendered | safe }}{% endif %}{% endif %}
 


### PR DESCRIPTION
Went from {% if blah blah %} type stuff to the CHAD {{ 'X' if true }} because it's shorter and better somehow. Idk how, it just is.

Adds two class names, "heralded" and "pinned". Works for COMMENTS ONLY (pr for posts later maybe).

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Allows for custom styles to be applied to comments based on it being pinned or heralded.

## How Has This Been Tested?
Local instance. (I literally went through hell trying to set it up)

## Screenshots (if appropriate):
v when using css to add a border v
![image](https://user-images.githubusercontent.com/49701242/125703186-615bc90a-ad63-4a20-8e5c-6b4979e081d4.png)
![image](https://user-images.githubusercontent.com/49701242/125703212-61594bb8-a939-4f7e-8c48-99b92fa3bc4e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
